### PR TITLE
payment_method_options support.

### DIFF
--- a/lib/entities/payment_intent.rb
+++ b/lib/entities/payment_intent.rb
@@ -2,23 +2,24 @@ module Payrex
   module Entities
     class PaymentIntent
       attr_reader :id,
-                  :resource,
-                  :amount,
-                  :capture_type,
-                  :client_secret,
-                  :currency,
-                  :description,
-                  :livemode,
-                  :metadata,
-                  :latest_payment,
-                  :payment_method_id,
-                  :payment_methods,
-                  :status,
-                  :next_action,
-                  :return_url,
-                  :capture_before_at,
-                  :created_at,
-                  :updated_at
+        :resource,
+        :amount,
+        :capture_type,
+        :client_secret,
+        :currency,
+        :description,
+        :livemode,
+        :metadata,
+        :latest_payment,
+        :payment_method_id,
+        :payment_methods,
+        :payment_method_options,
+        :status,
+        :next_action,
+        :return_url,
+        :capture_before_at,
+        :created_at,
+        :updated_at
 
       def initialize(api_resource)
         @id = api_resource.data["id"]
@@ -33,6 +34,7 @@ module Payrex
         @latest_payment = api_resource.data["latest_payment"]
         @payment_method_id = api_resource.data["payment_method_id"]
         @payment_methods = api_resource.data["payment_methods"]
+        @payment_method_options = api_resource.data["payment_method_options"]
         @status = api_resource.data["status"]
         @next_action = api_resource.data["next_action"]
         @return_url = api_resource.data["return_url"]

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,8 @@
+## 🤔 What?
+- 
+
+## 🤔 Why?
+- 
+
+## 📝 Additional Notes
+- 


### PR DESCRIPTION
## 🤔 What?
- Support payment_method_options in PaymentIntent resource.

## 🤔 Why?
- To allow merchants to reference the `payment_method_options` of a PaymentIntent.

## 📝 Additional Notes
- Add pull request template.